### PR TITLE
Dev environment improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "cd packages/showcase && yarn start",
     "build": "cd packages/showcase && npm run build",
+    "add:build:scripts": "node scripts/add-build-scripts.js",
     "bootstrap": "lerna bootstrap",
     "postinstall": "npm run bootstrap",
     "clean": "rm -rf node_modules && rm -rf packages/*/node_modules",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -18,10 +18,11 @@
     "test:watch": "jest --watch",
     "lint": "tslint './src/**/*.{ts,tsx}' --fix",
     "prettier": "prettier './src/**/*.{ts,tsx}' --write",
-    "precommit": "npm run test && npm run lint && npm run prettier && npm run package",
+    "precommit": "npm run prettier",
     "preversion": "npm run precommit",
     "version": "npm run package && git add lib",
-    "test:u": "jest -u"
+    "test:u": "jest -u",
+    "ci": "npm run test && npm run lint && npm run prettier && npm run package"
   },
   "peerDependencies": {
     "glamor": "^2.20.40",
@@ -101,6 +102,10 @@
     "@types/react-router-dom": "4.2.0",
     "@types/react-syntax-highlighter": "0.0.3",
     "@types/tinycolor2": "1.4.0",
-    "@types/webpack-env": "1.13.1"
+    "@types/webpack-env": "1.13.1",
+    "webpack": "3.10.0",
+    "webpack-dev-server": "2.9.7",
+    "webpack-merge": "4.1.1",
+    "awesome-typescript-loader": "3.4.1"
   }
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -17,10 +17,11 @@
     "test": "jest",
     "lint": "tslint './src/**/*.{ts,tsx}' --fix",
     "prettier": "prettier './src/**/*.{ts,tsx}' --write",
-    "precommit": "npm run test && npm run lint && npm run prettier && npm run package",
+    "precommit": "npm run prettier",
     "preversion": "npm run precommit",
     "version": "npm run package && git add lib",
-    "test:u": "jest -u"
+    "test:u": "jest -u",
+    "ci": "npm run test && npm run lint && npm run prettier && npm run package"
   },
   "peerDependencies": {
     "glamor": "^2.20.40",
@@ -64,7 +65,7 @@
     "@types/react-syntax-highlighter": "0.0.3",
     "@types/tinycolor2": "1.4.0",
     "@types/webpack-env": "1.13.1",
-    "awesome-typescript-loader": "^3.4.1",
+    "awesome-typescript-loader": "3.4.1",
     "enzyme": "2.9.1",
     "enzyme-to-json": "1.5.1",
     "jest": "21.2.1",
@@ -77,7 +78,10 @@
     "tslint": "5.7.0",
     "tslint-config-airbnb": "5.2.1",
     "tslint-config-prettier": "1.5.0",
-    "typescript": "2.6.2"
+    "typescript": "2.6.2",
+    "webpack": "3.10.0",
+    "webpack-dev-server": "2.9.7",
+    "webpack-merge": "4.1.1"
   },
   "jest": {
     "setupFiles": [

--- a/packages/showcase/package.json
+++ b/packages/showcase/package.json
@@ -13,10 +13,11 @@
     "version": "npm run build && git add -A dist",
     "prettier": "prettier './src/**/*.{ts,tsx}' --write",
     "lint": "tslint './src/**/*.{ts,tsx}' --fix",
-    "precommit": "npm run test && npm run lint && npm run prettier && npm run package",
+    "precommit": "npm run prettier",
     "test": "jest",
     "test:u": "jest -u",
-    "package": "echo 'Showcase is not published, hence no package script.'"
+    "package": "echo 'Showcase is not published, hence no package script.'",
+    "ci": "npm run test && npm run lint && npm run prettier && npm run package"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^4.0.1",
@@ -24,9 +25,9 @@
     "html-webpack-plugin": "^2.30.1",
     "raw-loader": "^0.5.1",
     "ts-loader": "^3.1.1",
-    "webpack": "^3.6.0",
-    "webpack-dev-server": "^2.9.4",
-    "webpack-merge": "^4.1.0",
+    "webpack": "3.10.0",
+    "webpack-dev-server": "2.9.7",
+    "webpack-merge": "4.1.1",
     "@types/enzyme": "3.1.5",
     "@types/jest": "20.0.8",
     "@types/node": "8.0.27",
@@ -60,7 +61,8 @@
     "@types/react-router-dom": "4.2.0",
     "@types/react-syntax-highlighter": "0.0.3",
     "@types/tinycolor2": "1.4.0",
-    "@types/webpack-env": "1.13.1"
+    "@types/webpack-env": "1.13.1",
+    "awesome-typescript-loader": "3.4.1"
   },
   "dependencies": {
     "component-playground": "^3.0.0",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -15,11 +15,12 @@
     "package:watch": "tsc -d -w",
     "lint": "tslint './src/**/*.{ts,tsx}' --fix",
     "prettier": "prettier './src/**/*.{ts,tsx}' --write",
-    "precommit": "npm run test && npm run lint && npm run prettier && npm run package",
+    "precommit": "npm run prettier",
     "preversion": "npm run precommit",
     "version": "npm run package",
-    "test": "echo 'No tests at the moment'",
-    "test:u": "jest -u"
+    "test": "jest",
+    "test:u": "jest -u",
+    "ci": "npm run test && npm run lint && npm run prettier && npm run package"
   },
   "devDependencies": {
     "@types/enzyme": "3.1.5",
@@ -55,7 +56,11 @@
     "@types/react-router-dom": "4.2.0",
     "@types/react-syntax-highlighter": "0.0.3",
     "@types/tinycolor2": "1.4.0",
-    "@types/webpack-env": "1.13.1"
+    "@types/webpack-env": "1.13.1",
+    "webpack": "3.10.0",
+    "webpack-dev-server": "2.9.7",
+    "webpack-merge": "4.1.1",
+    "awesome-typescript-loader": "3.4.1"
   },
   "jest": {
     "setupFiles": [

--- a/packages/theme/src/__tests__/index.test.ts
+++ b/packages/theme/src/__tests__/index.test.ts
@@ -1,0 +1,8 @@
+import { contiamoTheme } from "../index"
+
+describe("contiamoTheme", () => {
+  it("has a title typography element", () => {
+    const heading1 = contiamoTheme.typography.heading1
+    expect(typeof heading1 === "object" && heading1 !== null).toBe(true)
+  })
+})

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,10 +17,11 @@
     "test:watch": "jest --watch",
     "lint": "tslint './src/**/*.{ts,tsx}' --fix",
     "prettier": "prettier './src/**/*.{ts,tsx}' --write",
-    "precommit": "npm run test && npm run lint && npm run prettier && npm run package",
+    "precommit": "npm run prettier",
     "preversion": "npm run precommit",
     "version": "npm run package && git add .",
-    "test:u": "jest -u"
+    "test:u": "jest -u",
+    "ci": "npm run test && npm run lint && npm run prettier && npm run package"
   },
   "dependencies": {
     "@operational/theme": "0.1.0-1",
@@ -64,7 +65,11 @@
     "@types/react-router-dom": "4.2.0",
     "@types/react-syntax-highlighter": "0.0.3",
     "@types/tinycolor2": "1.4.0",
-    "@types/webpack-env": "1.13.1"
+    "@types/webpack-env": "1.13.1",
+    "webpack": "3.10.0",
+    "webpack-dev-server": "2.9.7",
+    "webpack-merge": "4.1.1",
+    "awesome-typescript-loader": "3.4.1"
   },
   "jest": {
     "setupFiles": [

--- a/packages/visualizations/package.json
+++ b/packages/visualizations/package.json
@@ -11,13 +11,15 @@
     "registry": "https://npm.contiamo.com/"
   },
   "scripts": {
-    "test": "echo 'No tests at the moment'",
+    "dev": "node scripts/dev-server/index.js",
+    "test": "jest",
     "package": "rm -rf lib && tsc -d",
     "package:watch": "rm -rf lib && tsc -w",
     "prettier": "prettier './src/**/*.{ts,tsx}' --write",
     "lint": "tslint './src/**/*.{ts,tsx}' --fix",
-    "precommit": "npm run test && npm run lint && npm run prettier && npm run package",
-    "test:u": "jest -u"
+    "precommit": "npm run prettier",
+    "test:u": "jest -u",
+    "ci": "npm run test && npm run lint && npm run prettier && npm run package"
   },
   "dependencies": {
     "d3": "^4.10.2",
@@ -61,7 +63,11 @@
     "@types/react-router-dom": "4.2.0",
     "@types/react-syntax-highlighter": "0.0.3",
     "@types/tinycolor2": "1.4.0",
-    "@types/webpack-env": "1.13.1"
+    "@types/webpack-env": "1.13.1",
+    "webpack": "3.10.0",
+    "webpack-dev-server": "2.9.7",
+    "webpack-merge": "4.1.1",
+    "awesome-typescript-loader": "3.4.1"
   },
   "jest": {
     "setupFiles": [

--- a/packages/visualizations/scripts/dev-server/index.html
+++ b/packages/visualizations/scripts/dev-server/index.html
@@ -1,0 +1,2 @@
+<div id="app"></div>
+<script src="/bundle.js"></script>

--- a/packages/visualizations/scripts/dev-server/index.js
+++ b/packages/visualizations/scripts/dev-server/index.js
@@ -1,0 +1,33 @@
+const path = require("path")
+const webpack = require("webpack")
+const WebpackDevServer = require("webpack-dev-server")
+
+const config = {
+  entry: path.resolve(__dirname, "site.tsx"),
+  output: {
+    path: path.resolve(__dirname),
+    publicPath: "/",
+    filename: "bundle.js"
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(ts|tsx)/,
+        loader: "awesome-typescript-loader",
+        exclude: /node_modules/
+      }
+    ]
+  },
+  resolve: {
+    extensions: [".tsx", ".ts", ".js"]
+  },
+  plugins: []
+}
+
+const compiler = webpack(config)
+const server = new WebpackDevServer(compiler, {
+  contentBase: path.resolve(__dirname),
+  historyApiFallback: true
+})
+
+server.listen(8080)

--- a/packages/visualizations/scripts/dev-server/site.tsx
+++ b/packages/visualizations/scripts/dev-server/site.tsx
@@ -1,0 +1,68 @@
+import * as React from "react"
+import { render } from "react-dom"
+import { forEach } from "lodash/fp"
+import { injectStylesheet, baseStylesheet } from "@operational/utils"
+import { contiamoTheme } from "@operational/theme"
+
+injectStylesheet(baseStylesheet(contiamoTheme))
+
+const containerNode = document.getElementById("app")
+
+import ProcessFlow from "../../src/ProcessFlow/facade"
+
+const data = {
+  journeys: [{ path: ["1", "3", "4"], size: 1500 }, { path: ["2", "3", "4"], size: 1200 }],
+  nodes: [{ id: "1", group: "start" }, { id: "2", group: "start" }, { id: "3" }, { id: "4", group: "end" }]
+}
+
+const accessors = {
+  node: {
+    color: (node: any) => {
+      if (node.group === "start") {
+        return "lightgreen"
+      }
+      if (node.group === "end") {
+        return "lightcoral"
+      }
+      return "#fff"
+    },
+    shape: (node: any) => {
+      if (node.group === "start") {
+        return "square"
+      }
+      if (node.group === "end") {
+        return "circle"
+      }
+      return "squareDiamond"
+    },
+    stroke: (node: any) => {
+      return node.group ? "none" : "#000"
+    }
+  },
+  link: {
+    stroke: (link: any) => {
+      if (link.source.attributes.group === "start") {
+        return "lightgreen"
+      }
+      if (link.target.attributes.group === "end") {
+        return "lightcoral"
+      }
+      return "#bbb"
+    }
+  }
+}
+
+const config = {
+  maxNodeSize: 800,
+  nodeBorderWidth: 4
+}
+
+const viz = new ProcessFlow(containerNode)
+
+viz.data(data)
+forEach.convert({ cap: false })((accessors: any, key: string): void => {
+  viz.accessors(key, accessors)
+})(accessors)
+viz.config(config)
+
+viz.draw()

--- a/scripts/add-build-scripts.js
+++ b/scripts/add-build-scripts.js
@@ -7,7 +7,8 @@ const scripts = {
   test: "jest",
   "test:u": "jest -u",
   package: "rm -rf lib && tsc -d",
-  precommit: "npm run test && npm run lint && npm run prettier && npm run package"
+  precommit: "npm run prettier",
+  ci: "npm run test && npm run lint && npm run prettier && npm run package"
 }
 
 const jest = {
@@ -111,7 +112,11 @@ const devDependencies = {
   "jest-glamor-react": "3.1.0",
   "jest-serializer-enzyme": "1.0.0",
   "react-test-renderer": "16.0.0",
-  "ts-jest": "21.0.0"
+  "ts-jest": "21.0.0",
+  webpack: "3.10.0",
+  "webpack-dev-server": "2.9.7",
+  "webpack-merge": "4.1.1",
+  "awesome-typescript-loader": "3.4.1"
 }
 
 const packages = ["showcase", "blocks", "components", "theme", "utils", "visualizations"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -433,7 +433,7 @@ attr-accept@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-1.1.0.tgz#b5cd35227f163935a8f1de10ed3eba16941f6be6"
 
-awesome-typescript-loader@^3.4.1:
+awesome-typescript-loader@3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/awesome-typescript-loader/-/awesome-typescript-loader-3.4.1.tgz#22fa49800f0619ec18ab15383aef93b95378dea9"
   dependencies:
@@ -7390,7 +7390,7 @@ webpack-dev-middleware@^1.11.0:
     range-parser "^1.0.3"
     time-stamp "^2.0.0"
 
-webpack-dev-server@^2.9.4:
+webpack-dev-server@2.9.7:
   version "2.9.7"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.9.7.tgz#100ad6a14775478924d417ca6dcfb9d52a98faed"
   dependencies:
@@ -7422,7 +7422,7 @@ webpack-dev-server@^2.9.4:
     webpack-dev-middleware "^1.11.0"
     yargs "^6.6.0"
 
-webpack-merge@^4.1.0:
+webpack-merge@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.1.1.tgz#f1197a0a973e69c6fbeeb6d658219aa8c0c13555"
   dependencies:
@@ -7435,27 +7435,7 @@ webpack-sources@^1.0.1:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-1.15.0.tgz#4ff31f53db03339e55164a9d468ee0324968fe98"
-  dependencies:
-    acorn "^3.0.0"
-    async "^1.3.0"
-    clone "^1.0.2"
-    enhanced-resolve "~0.9.0"
-    interpret "^0.6.4"
-    loader-utils "^0.2.11"
-    memory-fs "~0.3.0"
-    mkdirp "~0.5.0"
-    node-libs-browser "^0.7.0"
-    optimist "~0.6.0"
-    supports-color "^3.1.0"
-    tapable "~0.1.8"
-    uglify-js "~2.7.3"
-    watchpack "^0.2.1"
-    webpack-core "~0.6.9"
-
-webpack@^3.6.0:
+webpack@3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.10.0.tgz#5291b875078cf2abf42bdd23afe3f8f96c17d725"
   dependencies:
@@ -7481,6 +7461,26 @@ webpack@^3.6.0:
     watchpack "^1.4.0"
     webpack-sources "^1.0.1"
     yargs "^8.0.2"
+
+webpack@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-1.15.0.tgz#4ff31f53db03339e55164a9d468ee0324968fe98"
+  dependencies:
+    acorn "^3.0.0"
+    async "^1.3.0"
+    clone "^1.0.2"
+    enhanced-resolve "~0.9.0"
+    interpret "^0.6.4"
+    loader-utils "^0.2.11"
+    memory-fs "~0.3.0"
+    mkdirp "~0.5.0"
+    node-libs-browser "^0.7.0"
+    optimist "~0.6.0"
+    supports-color "^3.1.0"
+    tapable "~0.1.8"
+    uglify-js "~2.7.3"
+    watchpack "^0.2.1"
+    webpack-core "~0.6.9"
 
 websocket-driver@>=0.5.1:
   version "0.7.0"


### PR DESCRIPTION
* in `components` and `visualizations`, simply run `npm run dev` to get a hot-reloading, standalone dev server to develop code without the showcase. I added some test code to `packages/{components|visualizations}/scripts/dev-server/site.tsx` that you can just change anytime (I don't care if it changes in version control, as it never ends up in production).
* precommit hook only runs `prettier` now. Travis will verify that `npm run ci` doesn't error out (test + lint + prettier + ...), and you can of course always run it locally before committing.